### PR TITLE
포스팅 관련 api 구현

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -61,16 +61,32 @@ model Writer {
   createdAt    DateTime       @default(now())
   updatedAt    DateTime       @updatedAt
   deleted      Boolean        @default(false)
-  PostWriter   PostWriter[]
+  posts        WritersOnPosts[]
 }
 
 model Tag {
     id      Int    @id @default(autoincrement())
     name    String @db.VarChar(31) @unique
-    PostTag PostTag[]
+    posts   TagsOnPosts[]
 }
 
-model PostTag {
+
+model Post {
+  id           Int            @id @default(autoincrement())
+  slug         String         @db.VarChar(127)
+  thumbnail    String         @db.VarChar(255)
+  title        String         @db.VarChar(255)
+  content      String         @db.LongText
+  language     Language       @default(en)
+  createdAt    DateTime       @default(now())
+  updatedAt    DateTime       @updatedAt
+  writers      WritersOnPosts[]
+  tags         TagsOnPosts[]
+
+  @@unique([slug, language])
+}
+
+model TagsOnPosts {
   postId Int
   tagId  Int
   post   Post @relation(fields: [postId], references: [id])
@@ -79,20 +95,7 @@ model PostTag {
   @@id([postId, tagId])
 }
 
-model Post {
-  id           Int            @id @default(autoincrement())
-  slug         String         @db.VarChar(127) @unique
-  thumbnail    String         @db.VarChar(255)
-  title        String         @db.VarChar(255)
-  content      String         @db.LongText
-  language     Language       @default(en)
-  createdAt    DateTime       @default(now())
-  updatedAt    DateTime       @updatedAt
-  PostWriter   PostWriter[]
-  PostTag      PostTag[]
-}
-
-model PostWriter {
+model WritersOnPosts {
   postId   Int
   writerId Int
   post     Post   @relation(fields: [postId], references: [id])

--- a/src/api/post/post.controller.ts
+++ b/src/api/post/post.controller.ts
@@ -1,0 +1,79 @@
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+  Query,
+  UploadedFile,
+  UseInterceptors,
+} from '@nestjs/common';
+import { FileInterceptor } from '@nestjs/platform-express';
+
+import { PostService } from '@/api/post/post.service';
+import { Language } from 'generated/client';
+
+@Controller('post')
+export class PostController {
+  constructor(private readonly postService: PostService) {}
+
+  @Get(':lang')
+  async getPostList(
+    @Param('lang') language: Language,
+    @Query() query: { slug?: string; tag?: string },
+  ) {
+    return this.postService.getPostList({ language, ...query });
+  }
+
+  @Get(':lang/:slug')
+  async getPost(
+    @Param('lang') language: Language,
+    @Param('slug') slug: string,
+  ) {
+    return this.postService.getPost({ language, slug });
+  }
+
+  @Post()
+  @UseInterceptors(FileInterceptor('file'))
+  async createPost(
+    @Body()
+    body: {
+      slug: string;
+      language: Language;
+      title: string;
+      content: string;
+      tags: string[];
+    },
+    @UploadedFile() file: Express.Multer.File,
+  ) {
+    return this.postService.createPost(body, file);
+  }
+
+  @Put(':lang/:slug')
+  @UseInterceptors(FileInterceptor('file'))
+  async updatePost(
+    @Param('lang') language: Language,
+    @Param('slug') slug: string,
+    @UploadedFile() file: Express.Multer.File,
+    @Body()
+    body: {
+      slug?: string;
+      title?: string;
+      content?: string;
+      tags?: string[];
+      thumbnail?: string;
+    },
+  ) {
+    return this.postService.updatePost({ language, slug }, body, file);
+  }
+
+  @Delete(':lang/:slug')
+  async deletePost(
+    @Param('lang') language: Language,
+    @Param('slug') slug: string,
+  ) {
+    return this.postService.deletePost({ language, slug });
+  }
+}

--- a/src/api/post/post.module.ts
+++ b/src/api/post/post.module.ts
@@ -1,0 +1,14 @@
+import { Module } from '@nestjs/common';
+
+import { PostController } from '@/api/post/post.controller';
+import { S3Service } from '@/api/s3/s3.service';
+import { PostRepo } from '@/repository/post.repo';
+import { S3Repo } from '@/repository/s3.repo';
+
+import { PostService } from './post.service';
+
+@Module({
+  controllers: [PostController],
+  providers: [PostService, PostRepo, S3Service, S3Repo],
+})
+export class PostModule {}

--- a/src/api/post/post.service.ts
+++ b/src/api/post/post.service.ts
@@ -1,0 +1,76 @@
+import { Injectable } from '@nestjs/common';
+
+import { S3Service } from '@/api/s3/s3.service';
+import { PostRepo } from '@/repository/post.repo';
+import { Language } from 'generated/client';
+
+const genRetWithConvertTags = ({
+  tags,
+  ...rest
+}: {
+  tags: { tag: { name: string } }[];
+}) => {
+  const _tags = tags.map((tag) => tag.tag.name);
+  return { ...rest, tags: _tags };
+};
+
+@Injectable()
+export class PostService {
+  constructor(
+    private readonly postRepo: PostRepo,
+    private readonly s3Service: S3Service,
+  ) {}
+
+  async getPostList(where: {
+    language: Language;
+    slug?: string;
+    tag?: string;
+  }) {
+    const list = await this.postRepo.getPostList(where);
+    return list.map(genRetWithConvertTags);
+  }
+
+  async getPost(data: { slug: string; language: Language }) {
+    return genRetWithConvertTags(await this.postRepo.getPost(data));
+  }
+
+  async createPost(
+    data: {
+      slug: string;
+      language: Language;
+      title: string;
+      content: string;
+      tags: string[];
+    },
+    file: Express.Multer.File,
+  ) {
+    const thumbnail = await this.s3Service.uploadFile(file, 'thumbnail');
+    return genRetWithConvertTags(
+      await this.postRepo.createPost({
+        ...data,
+        thumbnail,
+      }),
+    );
+  }
+
+  async updatePost(
+    where: { slug: string; language: Language },
+    data: {
+      slug?: string;
+      title?: string;
+      content?: string;
+      tags?: string[];
+      thumbnail?: string;
+    },
+    file?: Express.Multer.File,
+  ) {
+    if (file) {
+      data.thumbnail = await this.s3Service.uploadFile(file, 'thumbnail');
+    }
+    return genRetWithConvertTags(await this.postRepo.updatePost(where, data));
+  }
+
+  async deletePost(where: { slug: string; language: Language }) {
+    return this.postRepo.deletePost(where);
+  }
+}

--- a/src/api/s3/s3.service.ts
+++ b/src/api/s3/s3.service.ts
@@ -8,6 +8,10 @@ export class S3Service {
   constructor(private readonly s3Repo: S3Repo) {}
 
   async uploadFile(file: Express.Multer.File, path = 'post/') {
+    if (file.mimetype.split('/')[0] !== 'image') {
+      throw new Error('It is not image file');
+    }
+
     path = path.endsWith('/') ? path : path + '/';
     const ext = file.mimetype.split('/')[1];
     const key = path + uuid() + `.${ext}`;

--- a/src/api/writer/writer.controller.ts
+++ b/src/api/writer/writer.controller.ts
@@ -46,9 +46,6 @@ export class WriterController {
     @Body()
     body: { image?: string; name?: string; type?: WriterType },
   ) {
-    console.log('file', file);
-    console.log('body', body);
-
     return this.writerService.updateWriter(id, body, file);
   }
 

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -3,6 +3,7 @@ import { ConfigModule } from '@nestjs/config';
 
 import { DictionaryModule } from './api/dictionary/dictionary.module';
 import { GalleryModule } from './api/gallery/gallery.module';
+import { PostModule } from './api/post/post.module';
 import { S3Module } from './api/s3/s3.module';
 import { WriterModule } from './api/writer/writer.module';
 import { PrismaModule } from './prisma/prisma.module';
@@ -17,6 +18,7 @@ import { PrismaModule } from './prisma/prisma.module';
     DictionaryModule,
     GalleryModule,
     WriterModule,
+    PostModule,
   ],
 })
 export class AppModule {}

--- a/src/repository/post.repo.ts
+++ b/src/repository/post.repo.ts
@@ -1,0 +1,177 @@
+import { Injectable } from '@nestjs/common';
+
+import { PrismaService } from '@/prisma/prisma.service';
+import { Language } from 'generated/client';
+
+const TAKE = 10;
+
+@Injectable()
+export class PostRepo {
+  constructor(private readonly prisma: PrismaService) {}
+
+  async getPostList({
+    language,
+    slug,
+    tag,
+  }: {
+    language: Language;
+    slug?: string;
+    tag?: string;
+  }) {
+    return this.prisma.post.findMany({
+      where: {
+        language,
+        tags: {
+          some: {
+            tag: {
+              name: tag,
+            },
+          },
+        },
+      },
+      skip: slug ? 1 : 0,
+      take: TAKE,
+      cursor: slug && {
+        slug_language: {
+          slug,
+          language,
+        },
+      },
+      select: {
+        id: true,
+        slug: true,
+        thumbnail: true,
+        title: true,
+        tags: {
+          select: {
+            tag: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        },
+      },
+      orderBy: {
+        id: 'desc',
+      },
+    });
+  }
+
+  async getPost(slug_language: { slug: string; language: Language }) {
+    return this.prisma.post.findUnique({
+      where: { slug_language },
+      select: {
+        id: true,
+        tags: {
+          select: {
+            tag: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        },
+        thumbnail: true,
+        title: true,
+        content: true,
+      },
+    });
+  }
+
+  async createPost(data: {
+    language: Language;
+    slug: string;
+    thumbnail: string;
+    title: string;
+    content: string;
+    tags?: string[];
+  }) {
+    const { tags, ...rest } = data;
+    return this.prisma.post.create({
+      data: {
+        ...rest,
+        tags: {
+          create: tags?.map((tag) => ({
+            tag: {
+              connectOrCreate: { create: { name: tag }, where: { name: tag } },
+            },
+          })),
+        },
+      },
+      select: {
+        id: true,
+        slug: true,
+        thumbnail: true,
+        title: true,
+        content: true,
+        tags: {
+          select: {
+            tag: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  async updatePost(
+    slug_language: { slug: string; language: Language },
+    data: {
+      slug?: string;
+      thumbnail?: string;
+      title?: string;
+      content?: string;
+      tags?: string[];
+    },
+  ) {
+    const { tags, ...rest } = data;
+    return this.prisma.post.update({
+      where: {
+        slug_language: {
+          ...slug_language,
+        },
+      },
+      data: {
+        ...rest,
+        tags: {
+          deleteMany: {},
+          create: tags?.map((tag) => ({
+            tag: {
+              connectOrCreate: { create: { name: tag }, where: { name: tag } },
+            },
+          })),
+        },
+      },
+      select: {
+        id: true,
+        slug: true,
+        thumbnail: true,
+        title: true,
+        content: true,
+        tags: {
+          select: {
+            tag: {
+              select: {
+                name: true,
+              },
+            },
+          },
+        },
+      },
+    });
+  }
+
+  async deletePost(slug_language: { slug: string; language: Language }) {
+    return this.prisma.post.delete({
+      where: { slug_language },
+      select: {
+        id: true,
+        slug: true,
+      },
+    });
+  }
+}


### PR DESCRIPTION
* Closes #22 

## ✨ 구현 기능 명세
포스트와 관련된 api를 구현하였습니다.

## 🎁 PR Point
포스트와 관련된 api에서 unique한 키는 `id`가 아닌 `language`와 `slug`입니다. url을 통해 상시 확인할 수 있어서 id보다 용이하다고 판단하였습니다.

## 😭 어려웠던 점
N:M 관계와 관련된 prisma 쿼리문을 작성하는 것이 어려웠습니다. 

* post 작성시 존재하지 않는 태그 추가
* post 업데이트시 tag와 post 관계 변경

등 여러 어려움이 있었습니다.

## ⏰ 실제 소요 시간
2h 40m
