### PR TITLE
post와 writer 연결

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -55,13 +55,13 @@ model User {
 
 model Writer {
   id           Int            @id @default(autoincrement())
-  name         String         @db.VarChar(31)
+  name         String         @db.VarChar(31) @unique
   image        String         @db.VarChar(255)
   type         WriterType
   createdAt    DateTime       @default(now())
   updatedAt    DateTime       @updatedAt
   deleted      Boolean        @default(false)
-  posts        WritersOnPosts[]
+  posts        Post[]
 }
 
 model Tag {
@@ -78,12 +78,25 @@ model Post {
   title        String         @db.VarChar(255)
   content      String         @db.LongText
   language     Language       @default(en)
+  view         Int            @default(0)
   createdAt    DateTime       @default(now())
   updatedAt    DateTime       @updatedAt
-  writers      WritersOnPosts[]
   tags         TagsOnPosts[]
+  recommendedBy  Recommend[]  @relation("recommending")
+  recommending   Recommend[]  @relation("recommender")
+  writer       String
+  writerRelation      Writer         @relation(fields: [writer], references: [name])
 
   @@unique([slug, language])
+}
+
+model Recommend {
+    recommender Post @relation("recommender", fields: [recommenderId], references: [id])
+    recommenderId Int
+    recommending Post @relation("recommending", fields: [recommendingId], references: [id])
+    recommendingId Int
+
+    @@id([recommenderId, recommendingId])
 }
 
 model TagsOnPosts {
@@ -93,13 +106,4 @@ model TagsOnPosts {
   tag    Tag  @relation(fields: [tagId], references: [id])
 
   @@id([postId, tagId])
-}
-
-model WritersOnPosts {
-  postId   Int
-  writerId Int
-  post     Post   @relation(fields: [postId], references: [id])
-  writer   Writer @relation(fields: [writerId], references: [id])
-
-  @@id([postId, writerId])
 }

--- a/src/api/gallery/gallery.controller.ts
+++ b/src/api/gallery/gallery.controller.ts
@@ -35,8 +35,8 @@ export class GalleryController {
   ) {
     return this.galleryService.createGallery(
       {
-        language: lang,
         ...body,
+        language: lang,
       },
       file,
     );

--- a/src/api/post/post.controller.ts
+++ b/src/api/post/post.controller.ts
@@ -13,6 +13,7 @@ import {
 import { FileInterceptor } from '@nestjs/platform-express';
 
 import { PostService } from '@/api/post/post.service';
+import { NumberPipe } from '@/common/number.pipe';
 import { Language } from 'generated/client';
 
 @Controller('post')
@@ -22,9 +23,27 @@ export class PostController {
   @Get(':lang')
   async getPostList(
     @Param('lang') language: Language,
-    @Query() query: { slug?: string; tag?: string },
+    @Query() query: { tag?: string; writer?: string },
+    @Query('page', NumberPipe) page?: number,
+    @Query('limit', NumberPipe) limit?: number,
   ) {
-    return this.postService.getPostList({ language, ...query });
+    return this.postService.getPostList({
+      ...query,
+      language,
+      page,
+      limit,
+    });
+  }
+
+  @Get(':lang/count')
+  async getPostCount(
+    @Param('lang') language: Language,
+    @Query() query: { tag?: string; writer?: string },
+  ) {
+    return this.postService.getPostCount({
+      ...query,
+      language,
+    });
   }
 
   @Get(':lang/:slug')
@@ -42,6 +61,7 @@ export class PostController {
     body: {
       slug: string;
       language: Language;
+      writer: string;
       title: string;
       content: string;
       tags: string[];
@@ -60,6 +80,7 @@ export class PostController {
     @Body()
     body: {
       slug?: string;
+      writer?: string;
       title?: string;
       content?: string;
       tags?: string[];

--- a/src/common/number.pipe.ts
+++ b/src/common/number.pipe.ts
@@ -1,0 +1,13 @@
+import { Injectable, PipeTransform } from '@nestjs/common';
+
+@Injectable()
+export class NumberPipe implements PipeTransform {
+  transform(value: any): number | undefined {
+    if (value === undefined) return undefined;
+    else if (!isNaN(value)) {
+      return Number(value);
+    }
+
+    throw new Error('Invalid number');
+  }
+}


### PR DESCRIPTION
* Closes #26 

## ✨ 구현 기능 명세
Post와 Writer을 연결해주었습니다.

* 포스트 리스트 요청시 writer도 넣어 검색할 수 있습니다.
* 포스트 작성시 writer을 추가해줍니다.
* 포스트 리스트의 총 포스트 수를 알 수 있는 api를 추가하였습니다.

## 🎁 PR Point

Writer : Post 관계가 N:M 관계에서 1:N 관계로 변경되었습니다. 이에 따라 WritersOnPosts 테이블이 삭제되고 Post 테이블에 writer 컬럼이 추가되었습니다. 

포스트 리스트 요청시 기존에는 마지막 포스트를 전달하여 그 다음 포스트를 알 수 있도록 하였습니다. 하지만 이는 직관적이지 못하다고 생각하여 pagination을 적용하였습니다. 이제는 `page`와 `limit`를 전달하여 해당 페이지의 포스트 리스트를 얻을 수 있습니다.

## 😭 어려웠던 점
prisma에 alias 기능이 있을 것이라고 생각하여 이를 알아내는데 오래걸렸습니다. 하지만 이는 없었습니다. 그래서 service 단계에서 alias를 적용하였습니다.

## ⏰ 실제 소요 시간
3h 30m